### PR TITLE
Slice vm network tools images

### DIFF
--- a/slice-vm-centos8-network-tools/0.0.1/Dockerfile
+++ b/slice-vm-centos8-network-tools/0.0.1/Dockerfile
@@ -1,0 +1,14 @@
+# Dockerfile for experimenter vms needing network tools (iperf3, etc.)
+FROM centos:8
+MAINTAINER Paul Ruth <pruth@renci.org>
+LABEL maintainer="pruth@renci.org"
+
+ARG SLICE_VM_CENTOS8_NETWORK_TOOLS_VERSION=0.0.1
+
+
+RUN yum install -y iperf3
+RUN yum install -y tcpdump
+ 
+
+# cleanup
+RUN yum clean all 

--- a/slice-vm-centos8-network-tools/README.md
+++ b/slice-vm-centos8-network-tools/README.md
@@ -1,0 +1,7 @@
+### Image for Network Tools in a Slice VM
+
+This is a Docker image containing networking tools used inside of a FABRIC slice.
+
+The base image is the standard Centos8 image
+
+

--- a/slice-vm-p4-bmv2/0.0.1/Dockerfile
+++ b/slice-vm-p4-bmv2/0.0.1/Dockerfile
@@ -1,0 +1,70 @@
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN apt-get install -y cmake 
+RUN apt-get install -y g++ 
+RUN apt-get install -y git 
+RUN apt-get install -y automake 
+RUN apt-get install -y libtool 
+RUN apt-get install -y libgc-dev 
+RUN apt-get install -y bison 
+RUN apt-get install -y flex 
+RUN apt-get install -y libfl-dev 
+RUN apt-get install -y libgmp-dev 
+RUN apt-get install -y libboost-dev 
+RUN apt-get install -y libboost-iostreams-dev 
+RUN apt-get install -y libboost-graph-dev 
+RUN apt-get install -y llvm  
+RUN apt-get install -y pkg-config 
+RUN apt-get install -y python 
+RUN apt-get install -y python3-scapy 
+RUN apt-get install -y python3-ipaddr 
+RUN apt-get install -y python-ply 
+RUN apt-get install -y tcpdump 
+RUN apt-get install -y doxygen 
+RUN apt-get install -y graphviz 
+RUN apt-get install -y texlive-full 
+RUN apt-get install -y curl 
+RUN apt-get install -y vim 
+RUN apt-get install -y libssl-dev 
+RUN apt-get install -y lsb-core 
+RUN apt-get install -y sudo 
+
+WORKDIR /root
+RUN git clone https://github.com/protocolbuffers/protobuf.git
+WORKDIR /root/protobuf
+RUN git checkout v3.2.0
+RUN git submodule update --init --recursive
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
+RUN ldconfig
+
+WORKDIR /root
+RUN git clone --recursive https://github.com/p4lang/p4c.git
+RUN mkdir /root/p4c/build
+WORKDIR /root/p4c/build
+RUN cmake ..
+RUN make 
+RUN make install
+
+WORKDIR /root
+RUN git clone https://github.com/p4lang/behavioral-model.git
+WORKDIR /root/behavioral-model
+RUN sed -i 's/libssl1.0-dev/libssl-dev/g' install_deps.sh 
+RUN ./install_deps.sh
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
+RUN ldconfig
+
+WORKDIR /root
+RUN mkdir simple_p4_router
+WORKDIR /root/simple_p4_router
+COPY simple_router.p4 /root/simple_p4_router
+RUN p4c -b bmv2 simple_router.p4 -o simple_router.bmv2
+
+RUN apt-get install -y iproute2
+WORKDIR /root

--- a/slice-vm-p4-bmv2/0.0.1/simple_router.p4
+++ b/slice-vm-p4-bmv2/0.0.1/simple_router.p4
@@ -1,0 +1,130 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+
+header ethernet_t {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    bit<16>         ether_type;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct metadata_t {
+}
+
+error {
+    IPv4IncorrectVersion,
+    IPv4OptionsNotSupported
+}
+
+parser my_parser(packet_in packet,
+                out headers_t hd,
+                inout metadata_t meta,
+                inout standard_metadata_t standard_meta)
+{
+    state start {
+        packet.extract(hd.ethernet);
+        transition select(hd.ethernet.ether_type) {
+            0x0800:  parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hd.ipv4);
+        verify(hd.ipv4.version == 4w4, error.IPv4IncorrectVersion);
+        verify(hd.ipv4.ihl == 4w5, error.IPv4OptionsNotSupported);
+        transition accept;
+    }    
+}
+
+control my_deparser(packet_out packet,
+                   in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control my_verify_checksum(inout headers_t hdr,
+                         inout metadata_t meta)
+{
+    apply { }
+}
+
+control my_compute_checksum(inout headers_t hdr,
+                          inout metadata_t meta)
+{
+    apply { }
+}
+
+control my_ingress(inout headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t standard_metadata)
+{
+    bool dropped = false;
+
+    action drop_action() {
+        mark_to_drop(standard_metadata);
+        dropped = true;
+    }
+
+    action to_port_action(bit<9> port) {
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+        standard_metadata.egress_spec = port;
+    }
+
+    table ipv4_match {
+        key = {
+            hdr.ipv4.dst_addr: lpm;
+        }
+        actions = {
+            drop_action;
+            to_port_action;
+        }
+        size = 1024;
+        default_action = drop_action;
+    }
+
+    apply {
+        ipv4_match.apply();
+        if (dropped) return;
+    }
+}
+
+control my_egress(inout headers_t hdr,
+                 inout metadata_t meta,
+                 inout standard_metadata_t standard_metadata)
+{
+    apply { }
+}
+
+V1Switch(my_parser(),
+         my_verify_checksum(),
+         my_ingress(),
+         my_egress(),
+         my_compute_checksum(),
+         my_deparser()) main;
+

--- a/slice-vm-p4-bmv2/README.md
+++ b/slice-vm-p4-bmv2/README.md
@@ -1,0 +1,7 @@
+### Image with P4 software tools including the BMV2 software switch 
+
+This is a Docker image containing tools necessary to run a P4 software switch on FABRIC.
+
+The base image is the standard Ubuntu20 image
+
+

--- a/slice-vm-ubuntu20-network-tools/0.0.1/Dockerfile
+++ b/slice-vm-ubuntu20-network-tools/0.0.1/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile for experimenter vms needing network tools (iperf3, etc.)
+FROM ubuntu:20.04
+MAINTAINER Paul Ruth <pruth@renci.org>
+LABEL maintainer="pruth@renci.org"
+
+ARG SLICE_VM_UBUNTU20_NETWORK_TOOLS_VERSION=0.0.1
+
+
+RUN apt-get update
+RUN apt-get install -y net-tools
+RUN apt-get install -y iperf3
+
+
+# cleanup
+RUN apt-get clean all 

--- a/slice-vm-ubuntu20-network-tools/README.md
+++ b/slice-vm-ubuntu20-network-tools/README.md
@@ -1,0 +1,7 @@
+### Ubuntu Image for Network Tools in a Slice VM
+
+This is a Docker image containing networking tools used inside of a FABRIC slice.
+
+The base image is the standard Ubuntu20 image
+
+


### PR DESCRIPTION
Initial commit of docker image definitions for 3 images to be used by users in their VMs

- slice-vm-centos8-network-tools : Basic centos8 image with network tools such as iperf3
- slice-vm-ubuntu20-network-tools:  Basic ubuntu20 image with network tools such as iperf3
- slice-vm-p4-bmv2: Image with p4 compiler and bmv2 software switch