### PR TITLE
Fixing the fablib version to 1.4.4

### DIFF
--- a/jupyter-notebook/1.4.3/requirements.txt
+++ b/jupyter-notebook/1.4.3/requirements.txt
@@ -25,4 +25,4 @@ python-openstackclient
 python-chi
 wget
 jupyternb-setup==1.3.3
-fabrictestbed-extensions==1.4.6
+fabrictestbed-extensions==1.4.4


### PR DESCRIPTION
Fixing the fablib version to 1.4.4