### PR TITLE
setuptools user older version

### DIFF
--- a/jupyter-notebook/3.3.7/requirements.txt
+++ b/jupyter-notebook/3.3.7/requirements.txt
@@ -30,3 +30,4 @@ openstacksdk
 pyopenssl
 cryptography
 python-chi
+setuptools==66.1.1


### PR DESCRIPTION
use older setuptools to avoid networkx_query import warning until addressed by networkx_query

Without this change, following warning shows up on the notebooks:
```
/opt/conda/lib/python3.11/site-packages/networkx_query/__init__.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import DistributionNotFound, get_distribution
```