### PR TITLE
Support for using core-api for verifying User Roles and using FABRIC user ID as username

### DIFF
--- a/jupyterhub-k8s/1.9.0/Dockerfile
+++ b/jupyterhub-k8s/1.9.0/Dockerfile
@@ -1,0 +1,5 @@
+ARG BASE_JH=quay.io/jupyterhub/k8s-hub:4.2.0
+FROM $BASE_JH
+COPY requirements.txt /srv/jupyterhub/requirements.txt
+RUN pip3 install --no-cache-dir -r /srv/jupyterhub/requirements.txt
+

--- a/jupyterhub-k8s/1.9.0/requirements.txt
+++ b/jupyterhub-k8s/1.9.0/requirements.txt
@@ -1,0 +1,3 @@
+oauthenticator
+ldap3
+fabricauthenticator==1.3.3b4

--- a/jupyterhub-k8s/1.9.0/requirements.txt
+++ b/jupyterhub-k8s/1.9.0/requirements.txt
@@ -1,3 +1,3 @@
 oauthenticator
 ldap3
-fabricauthenticator==1.3.3b4
+fabricauthenticator==1.3.3


### PR DESCRIPTION
Support for using core-api for verifying User Roles and using FABRIC user ID as username

Enables user migration across organizations/email changes without affecting PVC volume changes