### PR TITLE
revert back to older jh image

### DIFF
--- a/jupyterhub-k8s/1.9.0/Dockerfile
+++ b/jupyterhub-k8s/1.9.0/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_JH=quay.io/jupyterhub/k8s-hub:4.2.0
+ARG BASE_JH=quay.io/jupyterhub/k8s-hub:3.3.7
 FROM $BASE_JH
 COPY requirements.txt /srv/jupyterhub/requirements.txt
 RUN pip3 install --no-cache-dir -r /srv/jupyterhub/requirements.txt

--- a/jupyterhub-k8s/1.9.0/requirements.txt
+++ b/jupyterhub-k8s/1.9.0/requirements.txt
@@ -1,3 +1,3 @@
 oauthenticator
 ldap3
-fabricauthenticator==1.3.4rc0
+fabricauthenticator==1.3.4

--- a/jupyterhub-k8s/1.9.0/requirements.txt
+++ b/jupyterhub-k8s/1.9.0/requirements.txt
@@ -1,3 +1,3 @@
 oauthenticator
 ldap3
-fabricauthenticator==1.3.3
+fabricauthenticator==1.3.4rc0


### PR DESCRIPTION
Revert to an older JupyterHub base image to ensure consistent PVC naming based on FABRIC user IDs.
The JupyterHub 4.2.0 base image introduces a bug where PVC names are no longer derived from usernames, resulting in inconsistent volume naming and failed data recovery.