### PR TITLE
Fab cache rathole server

### DIFF
--- a/fab-cache-rathole-server/0.1.0/Dockerfile
+++ b/fab-cache-rathole-server/0.1.0/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Ubuntu base image
+FROM ubuntu:latest
+
+# Set the working directory in the container
+WORKDIR /workspace
+
+# Install dependencies: wget and unzip
+RUN apt update && apt install -y wget unzip
+
+# Download and install Rathole (Linux x86_64, glibc-based)
+RUN wget https://github.com/rathole-org/rathole/releases/download/v0.5.0/rathole-x86_64-unknown-linux-gnu.zip \
+    && unzip rathole-x86_64-unknown-linux-gnu.zip \
+    && chmod +x rathole \
+    && rm rathole-x86_64-unknown-linux-gnu.zip
+
+# Copy your config file into the container
+COPY server.toml /workspace/
+
+# Run Rathole with the config when container starts
+CMD ["./rathole", "server.toml"]

--- a/fab-cache-rathole-server/0.1.0/server.toml
+++ b/fab-cache-rathole-server/0.1.0/server.toml
@@ -1,0 +1,4 @@
+# server.toml
+[server]
+
+[server.services.my_nas_ssh]

--- a/fab-cache-rathole-server/README.md
+++ b/fab-cache-rathole-server/README.md
@@ -1,0 +1,7 @@
+# fab-cache-rathole-server
+
+Docker-based reverse proxy using [Rathole](https://github.com/rathole-org/rathole).
+
+## Available Versions
+
+- [`0.1.0`](./0.1.0/) – initial setup with `server.toml` and `Dockerfile`


### PR DESCRIPTION
This docker container will be run on the machines outside FABRIC to set up a rathole tunnel connection to the FAB-Cache nodes. VMs with public IP will be the rathole server and the FAB-Cache node will be the rathole client.  We will use it during the PEARC tutorial if we cannot take advantage of the facility port approach to connect FAB-Cache node to DTN nodes.