### PR TITLE
increase the number of maxNumOfImmediateChildren and maxDepth to 1000

### DIFF
--- a/authzforce-pdp/6.1.0/conf/spring-beans.xml
+++ b/authzforce-pdp/6.1.0/conf/spring-beans.xml
@@ -85,10 +85,10 @@
 					value="1000" />
 				<constructor-arg
 					name="maxNumOfImmediateChildren"
-					value="100" />
+					value="1000" />
 				<constructor-arg
 					name="maxDepth"
-					value="100" />
+					value="1000" />
 			</bean>
 			<bean class="org.ow2.authzforce.jaxrs.util.BadRequestExceptionMapper" />
 			<bean class="org.ow2.authzforce.jaxrs.util.ClientErrorExceptionMapper" />


### PR DESCRIPTION
Allow for increased tags in PDP request as number of tags in FABRIC-Staff project now exceeds the initial default
- increase the number of maxNumOfImmediateChildren and maxDepth to 1000
