### PR TITLE
Fix loomai 0.0.2 frontend build: npm ci after full source copy

### DIFF
--- a/loomai/0.0.2/Dockerfile
+++ b/loomai/0.0.2/Dockerfile
@@ -14,10 +14,11 @@ ARG LOOMAI_REPO
 RUN git clone --depth 1 --branch ${LOOMAI_VERSION} ${LOOMAI_REPO} /src
 
 # --- Stage 2: Build frontend ---
-FROM node:18-alpine AS frontend-build
+FROM node:20-alpine AS frontend-build
 WORKDIR /app
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 COPY --from=source /src/frontend/ .
-RUN npm ci --prefer-offline --no-audit && npm run build && rm -rf node_modules
+RUN npm ci --no-audit && npm run build && rm -rf node_modules
 
 # --- Stage 3: Final image ---
 FROM python:3.11-slim

--- a/loomai/0.0.2/Dockerfile
+++ b/loomai/0.0.2/Dockerfile
@@ -16,10 +16,8 @@ RUN git clone --depth 1 --branch ${LOOMAI_VERSION} ${LOOMAI_REPO} /src
 # --- Stage 2: Build frontend ---
 FROM node:18-alpine AS frontend-build
 WORKDIR /app
-COPY --from=source /src/frontend/package.json /src/frontend/package-lock.json ./
-RUN npm ci --prefer-offline --no-audit && npm cache clean --force
 COPY --from=source /src/frontend/ .
-RUN npm run build && rm -rf node_modules
+RUN npm ci --prefer-offline --no-audit && npm run build && rm -rf node_modules
 
 # --- Stage 3: Final image ---
 FROM python:3.11-slim


### PR DESCRIPTION
## Summary
- Fix `next: not found` build failure caused by `COPY --from=source` overwriting `node_modules` installed by the prior `npm ci` step
- Combine into a single RUN: copy all frontend source first, then `npm ci && npm run build`

## Context
Follows up on PR #110. The separated `npm ci` / `COPY` / `npm run build` pattern works with local `COPY` (overlay) but not with `COPY --from=source` (full directory replace).

## Test plan
- [ ] Build the image: `cd loomai/0.0.2 && docker build -t fabrictestbed/loomai:0.0.2 .`
- [ ] Verify frontend build stage completes without `next: not found` error