### PR TITLE
Add loomai 0.0.3 Docker image

### DIFF
--- a/loomai/0.0.3/Dockerfile
+++ b/loomai/0.0.3/Dockerfile
@@ -1,0 +1,163 @@
+# LoomAI - AI-assisted experiment designer for FABRIC testbed
+# Builds a single container with FastAPI backend + React/Next.js frontend + Nginx
+#
+# Convention: fabrictestbed/loomai:<version>
+# Source:     https://github.com/fabric-testbed/loomai
+
+ARG LOOMAI_VERSION=v0.0.3
+ARG LOOMAI_REPO=https://github.com/fabric-testbed/loomai.git
+
+# --- Stage 1: Clone source ---
+FROM alpine/git:latest AS source
+ARG LOOMAI_VERSION
+ARG LOOMAI_REPO
+RUN git clone --depth 1 --branch ${LOOMAI_VERSION} ${LOOMAI_REPO} /src
+
+# --- Stage 2: Build frontend ---
+FROM node:20-alpine AS frontend-build
+WORKDIR /app
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+COPY --from=source /src/frontend/ .
+RUN npm ci --no-audit && npm run build && rm -rf node_modules
+
+# --- Stage 3: Final image ---
+FROM python:3.11-slim
+
+LABEL maintainer="komal.thareja@gmail.com"
+LABEL org.opencontainers.image.source="https://github.com/fabric-testbed/loomai"
+
+WORKDIR /app
+
+# Install all system deps in one layer: build tools, runtime, Node.js
+# Build deps (gcc, python3-dev, libffi-dev) are purged after pip install
+COPY --from=source /src/backend/requirements.txt .
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc python3-dev libffi-dev libssl-dev \
+    openssh-client git nginx supervisor tmux sudo curl \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apt-get purge -y gcc python3-dev libffi-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
+
+# Create fabric user with passwordless sudo
+RUN useradd -m -s /bin/bash -d /home/fabric fabric && \
+    echo "fabric ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/fabric && \
+    chmod 0440 /etc/sudoers.d/fabric
+
+# Nginx + supervisor config (changes rarely — good cache layer)
+RUN rm -f /etc/nginx/sites-enabled/default \
+    && (sed -i 's|pid /run/nginx.pid;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf || \
+        sed -i '1i pid /tmp/nginx.pid;' /etc/nginx/nginx.conf) \
+    && mkdir -p /var/cache/nginx /var/log/nginx /etc/nginx/conf.d /var/lib/nginx \
+    && chown -R fabric:fabric /var/cache/nginx /var/log/nginx /etc/nginx/conf.d /var/lib/nginx
+
+RUN cat > /etc/nginx/conf.d/default.conf <<'NGINX'
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 3000;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 500m;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+
+    location /jupyter/ {
+        proxy_pass http://127.0.0.1:8889;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+}
+NGINX
+
+RUN cat > /etc/supervisor/conf.d/fabric-webui.conf <<'CONF'
+[supervisord]
+nodaemon=true
+user=root
+logfile=/dev/stdout
+logfile_maxbytes=0
+
+[program:backend]
+command=uvicorn app.main:app --host 0.0.0.0 --port 8000
+directory=/app
+user=fabric
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=nginx -g "daemon off;"
+user=fabric
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+CONF
+
+# Copy static assets that change occasionally
+COPY --from=source /src/ai-tools/ ai-tools/
+
+# Copy built frontend (changes on frontend builds)
+COPY --from=frontend-build /app/dist /usr/share/nginx/html
+
+# Copy backend code (changes most often — last for best cache)
+COPY --from=source /src/backend/app/ app/
+COPY --from=source /src/backend/scripts/ scripts/
+COPY --from=source /src/frontend/src/version.ts /app/VERSION
+
+# Set up fabric user home and storage
+RUN mkdir -p /home/fabric/work/fabric_config && chown -R fabric:fabric /home/fabric
+ENV FABRIC_CONFIG_DIR=/home/fabric/work/fabric_config
+ENV FABRIC_STORAGE_DIR=/home/fabric/work
+ENV HOME=/home/fabric
+
+# Copy entrypoint script
+COPY --from=source /src/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Frontend on 3000, backend on 8000, 8889 for JupyterLab, 9100-9199 for SSH tunnel proxies
+EXPOSE 3000 8000 8889 9100-9199
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/loomai/0.0.3/docker-compose.yml
+++ b/loomai/0.0.3/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  loomai:
+    image: fabrictestbed/loomai:latest
+    ports:
+      - "3000:3000"        # Web UI (nginx)
+      - "8000:8000"        # Backend API (direct access)
+      - "8889:8889"        # JupyterLab
+      - "9100-9199:9100-9199"  # SSH tunnels for My Web Apps
+    volumes:
+      - fabric_work:/home/fabric/work
+    environment:
+      - FABRIC_CONFIG_DIR=/home/fabric/work/fabric_config
+      - FABRIC_STORAGE_DIR=/home/fabric/work
+      - DOCKER_REPO=fabrictestbed/loomai
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    restart: unless-stopped
+
+volumes:
+  fabric_work:

--- a/loomai/README.md
+++ b/loomai/README.md
@@ -9,6 +9,7 @@ AI-assisted experiment designer for the [FABRIC testbed](https://fabric-testbed.
 
 | Version | LoomAI Release | Description |
 |---------|---------------|-------------|
+| 0.0.3   | v0.0.3        | Release 0.0.3 |
 | 0.0.2   | v0.0.2        | Aligned Dockerfile with upstream loomai repo |
 | 0.0.1   | v0.0.1        | Initial release |
 
@@ -26,14 +27,14 @@ AI-assisted experiment designer for the [FABRIC testbed](https://fabric-testbed.
 ### Docker Compose (recommended)
 
 ```bash
-curl -O https://raw.githubusercontent.com/fabric-testbed/fabric-docker-images/main/loomai/0.0.2/docker-compose.yml
+curl -O https://raw.githubusercontent.com/fabric-testbed/fabric-docker-images/main/loomai/0.0.3/docker-compose.yml
 docker compose up -d
 ```
 
 ### Docker Run
 
 ```bash
-docker pull fabrictestbed/loomai:0.0.2
+docker pull fabrictestbed/loomai:0.0.3
 docker run -d \
   -p 3000:3000 -p 8000:8000 -p 8889:8889 -p 9100-9199:9100-9199 \
   -v fabric_work:/home/fabric/work \
@@ -42,5 +43,5 @@ docker run -d \
   -e DOCKER_REPO=fabrictestbed/loomai \
   --dns 8.8.8.8 --dns 8.8.4.4 \
   --restart unless-stopped \
-  fabrictestbed/loomai:0.0.2
+  fabrictestbed/loomai:0.0.3
 ```


### PR DESCRIPTION
## Summary
- Add Dockerfile and docker-compose.yml for LoomAI v0.0.3 release
- Docker-compose uses `latest` tag for the image
- Update README with v0.0.3 version entry and usage examples

## Test plan
- [ ] Build image: `docker build --build-arg LOOMAI_VERSION=v0.0.3 -t fabrictestbed/loomai:0.0.3 loomai/0.0.3/`
- [ ] Run with docker-compose: `docker compose -f loomai/0.0.3/docker-compose.yml up -d`
- [ ] Verify web UI accessible on port 3000