### PR TITLE
Upgrade Node.js to 22 LTS in loomai 0.1.0

### DIFF
--- a/loomai/0.1.0/Dockerfile
+++ b/loomai/0.1.0/Dockerfile
@@ -14,7 +14,7 @@ ARG LOOMAI_REPO
 RUN git clone --depth 1 --branch ${LOOMAI_VERSION} ${LOOMAI_REPO} /src
 
 # --- Stage 2: Build frontend ---
-FROM node:20-alpine AS frontend-build
+FROM node:22-alpine AS frontend-build
 WORKDIR /app
 COPY --from=source /src/frontend/package.json /src/frontend/package-lock.json ./
 RUN npm ci --prefer-offline --no-audit && npm cache clean --force
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client git nginx supervisor tmux sudo curl \
     vim nano less htop strace tree jq wget rsync zip unzip \
     iputils-ping dnsutils net-tools traceroute ripgrep \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && pip install --no-cache-dir -r requirements.txt \
     && pip uninstall -y jupyter-collaboration jupyter-collaboration-ui jupyter-docprovider jupyter-server-ydoc jupyter-server-documents 2>/dev/null || true \


### PR DESCRIPTION
## Summary
- Upgrade `node:20-alpine` → `node:22-alpine` in frontend build stage
- Upgrade NodeSource `setup_20.x` → `setup_22.x` in runtime stage
- Matches the Node upgrade in fabric-testbed/loomai-dev#22

## Test plan
- [x] Docker build completes successfully