### PR TITLE
Add LoomAI 0.8.2 Docker image

### DIFF
--- a/loomai/0.8.2/Dockerfile
+++ b/loomai/0.8.2/Dockerfile
@@ -1,0 +1,273 @@
+# LoomAI - AI-assisted experiment designer for FABRIC testbed
+# Builds a single container with FastAPI backend + React/Next.js frontend + Nginx
+#
+# Convention: fabrictestbed/loomai:<version>
+# Source:     https://github.com/fabric-testbed/loomai
+
+ARG LOOMAI_VERSION=v0.8.2
+ARG LOOMAI_REPO=https://github.com/fabric-testbed/loomai.git
+
+# --- Stage 1: Clone source ---
+FROM alpine/git:latest AS source
+ARG LOOMAI_VERSION
+ARG LOOMAI_REPO
+RUN git clone --depth 1 --branch ${LOOMAI_VERSION} ${LOOMAI_REPO} /src
+
+# --- Stage 2: Build frontend ---
+FROM node:22-alpine AS frontend-build
+WORKDIR /app
+COPY --from=source /src/frontend/package.json /src/frontend/package-lock.json ./
+RUN npm ci --prefer-offline --no-audit && npm cache clean --force
+COPY --from=source /src/frontend/ .
+RUN npm run build && rm -rf node_modules
+
+# --- Stage 3: Final image ---
+FROM python:3.11-slim
+
+LABEL maintainer="komal.thareja@gmail.com"
+LABEL org.opencontainers.image.source="https://github.com/fabric-testbed/loomai"
+
+WORKDIR /app
+
+# Install all system deps in one layer: build tools, runtime, Node.js
+# Build deps (gcc, python3-dev, libffi-dev) are purged after pip install
+COPY --from=source /src/backend/requirements.txt .
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc python3-dev libffi-dev libssl-dev \
+    openssh-client git nginx supervisor tmux sudo curl bubblewrap \
+    vim nano less htop strace tree jq wget rsync zip unzip \
+    iputils-ping dnsutils net-tools traceroute ripgrep \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies (separate RUN so failures are not masked)
+# CFLAGS=-O0 avoids gcc SIGSEGV under QEMU when cross-compiling C extensions
+# like recordclass (transitive dep of fabrictestbed-extensions)
+RUN CFLAGS="-O0" pip install --no-cache-dir -r requirements.txt \
+    && (pip uninstall -y jupyter-collaboration jupyter-collaboration-ui jupyter-docprovider jupyter-server-ydoc jupyter-server-documents 2>/dev/null || true) \
+    && (rm -f /usr/local/etc/jupyter/jupyter_server_config.d/jupyter_server_documents.json \
+       /usr/local/etc/jupyter/jupyter_server_config.d/jupyter_collaboration.json 2>/dev/null || true)
+
+# Purge build deps
+RUN apt-get update && apt-get purge -y gcc python3-dev libffi-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
+
+# Create fabric user with passwordless sudo
+RUN useradd -m -s /bin/bash -d /home/fabric fabric && \
+    echo "fabric ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/fabric && \
+    chmod 0440 /etc/sudoers.d/fabric
+
+# Nginx + supervisor config (changes rarely — good cache layer)
+RUN rm -f /etc/nginx/sites-enabled/default \
+    && (sed -i 's|pid /run/nginx.pid;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf || \
+        sed -i '1i pid /tmp/nginx.pid;' /etc/nginx/nginx.conf) \
+    && mkdir -p /var/cache/nginx /var/log/nginx /etc/nginx/conf.d /var/lib/nginx \
+    && chown -R fabric:fabric /var/cache/nginx /var/log/nginx /etc/nginx/conf.d /var/lib/nginx
+
+RUN cat > /etc/nginx/conf.d/default.conf <<'NGINX'
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 3000;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 500m;
+    # nginx runs non-root (fabric) here and cannot write the default
+    # /var/lib/nginx/body temp dir, which breaks large uploads and Jupyter
+    # saves with "open() ... failed (13: Permission denied)". Buffer request
+    # bodies under the writable user-storage mount instead. See
+    # scripts/ensure-nginx-upload-temp.sh (run at startup) which creates it.
+    client_body_temp_path /home/fabric/work/.nginx-client-body 1 2;
+    client_body_timeout 300s;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Long-running synchronous slice operations — these SSH into every node and
+    # can far exceed the default 120s (FABlib post_boot_config, network auto-config,
+    # site re-resolution). Without this they hit nginx's 504 gateway timeout.
+    location ~ ^/api/slices/.+/(post-boot-config|auto-configure-networks|resolve-sites)$ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 1800s;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
+    # Internal auth gate for the embedded-tool proxies below (nginx auth_request).
+    # Proxies to the backend, which returns 200 when the loomai_session cookie is
+    # valid (or 200 unconditionally when auth is disabled, via AuthMiddleware) and
+    # 401 otherwise. Without this, JupyterLab/Aider/OpenCode/tunnels are reachable
+    # unauthenticated when the standalone container is exposed remotely.
+    location = /_auth_check {
+        internal;
+        proxy_pass http://127.0.0.1:8000/api/auth/check;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Host $host;
+        proxy_set_header Cookie $http_cookie;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 5s;
+    }
+
+    location ^~ /jupyter/ {
+        auth_request /_auth_check;
+        proxy_pass http://127.0.0.1:8889;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+
+    location ^~ /aider/ {
+        auth_request /_auth_check;
+        proxy_pass http://127.0.0.1:9197;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+
+    location ^~ /opencode/ {
+        auth_request /_auth_check;
+        proxy_pass http://127.0.0.1:9198;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+
+    location ~ ^/tunnel/(91[0-9][0-9])/(.*) {
+        auth_request /_auth_check;
+        proxy_pass http://127.0.0.1:$1/$2$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 604800s;
+        proxy_send_timeout 604800s;
+        proxy_buffering off;
+    }
+}
+NGINX
+
+RUN cat > /etc/supervisor/conf.d/fabric-webui.conf <<'CONF'
+[supervisord]
+nodaemon=true
+user=root
+logfile=/dev/stdout
+logfile_maxbytes=0
+
+[program:backend]
+command=uvicorn app.main:app --host 0.0.0.0 --port 8000
+directory=/app
+user=fabric
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=nginx -g "daemon off;"
+user=fabric
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+CONF
+
+# Copy static assets that change occasionally
+COPY --from=source /src/ai-tools/ ai-tools/
+
+# Install loomai CLI (pure Python — no compiled deps)
+COPY --from=source /src/cli/ /app/cli/
+RUN pip install --no-cache-dir /app/cli/ && rm -rf /app/cli/
+
+# Copy built frontend (changes on frontend builds)
+COPY --from=frontend-build /app/dist /usr/share/nginx/html
+
+# Copy backend code (changes most often — last for best cache)
+COPY --from=source /src/backend/app/ app/
+COPY --from=source /src/backend/scripts/ scripts/
+COPY --from=source /src/backend/default_artifacts/ default_artifacts/
+COPY --from=source /src/frontend/src/version.ts /app/VERSION
+
+# Set up fabric user home and storage
+RUN mkdir -p /home/fabric/work/fabric_config && chown -R fabric:fabric /home/fabric
+ENV FABRIC_CONFIG_DIR=/home/fabric/work/fabric_config
+ENV FABRIC_STORAGE_DIR=/home/fabric/work
+ENV HOME=/home/fabric
+# Keep the matplotlib cache on the storage mount: always writable (the
+# entrypoint chowns /home/fabric/work on every start) and persistent across
+# pod restarts, unlike the default ~/.cache which can end up root-owned.
+ENV MPLCONFIGDIR=/home/fabric/work/.cache/matplotlib
+# Marker: this combined image runs nginx in the same container as JupyterLab,
+# so the entrypoint binds JupyterLab to loopback (only the in-container nginx,
+# which enforces the loomai_session gate, can reach it). The split source build
+# (backend/Dockerfile) leaves this unset so its separate nginx container can
+# still reach JupyterLab over the Docker network.
+ENV LOOMAI_COMBINED_IMAGE=1
+
+# Copy entrypoint script
+COPY --from=source /src/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Frontend on 3000, backend on 8000, 8889 for JupyterLab, 9100-9199 for SSH tunnel proxies
+EXPOSE 3000 8000 8889 9100-9199
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/loomai/0.8.2/docker-compose.yml
+++ b/loomai/0.8.2/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  loomai:
+    image: fabrictestbed/loomai:0.8.2
+    ports:
+      - "127.0.0.1:3000:3000"        # Web UI (nginx) — the only entrypoint; proxies /api, /jupyter, /aider, /opencode, /tunnel with auth
+      - "127.0.0.1:9100-9199:9100-9199"  # SSH tunnels for My Web Apps
+      # Backend (8000) and JupyterLab (8889) are intentionally NOT published:
+      # reach them through nginx on 3000 so the loomai_session auth gate applies.
+      # Publishing 8889 would expose JupyterLab (no token/password) unauthenticated.
+    volumes:
+      - fabric_work:/home/fabric/work
+    environment:
+      - FABRIC_CONFIG_DIR=/home/fabric/work/fabric_config
+      - FABRIC_STORAGE_DIR=/home/fabric/work
+      - LOOMAI_PASSWORD=${LOOMAI_PASSWORD:-}    # Set a custom password (default: auto-generated, shown in logs)
+      - LOOMAI_NO_AUTH=${LOOMAI_NO_AUTH:-}      # Set to 1 to disable password protection (for trusted networks)
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  fabric_work:

--- a/loomai/README.md
+++ b/loomai/README.md
@@ -9,6 +9,7 @@ AI-assisted experiment designer for the [FABRIC testbed](https://fabric-testbed.
 
 | Version | LoomAI Release | Description |
 |---------|---------------|-------------|
+| 0.8.2    | v0.8.2         | SPHERE testbed integration (experiment builder, XDC access, weave packaging), terminal clipboard copy/paste, auth-gated JupyterLab/tool proxies, nginx upload and long-operation timeout fixes, writable matplotlib cache |
 | 0.7.3    | v0.7.3         | Popup/modal fixes, in-browser dropdown selectors, simplified add-VM-node form |
 | 0.7.2    | v0.7.2         | LoomAI CLI modernization (expanded command coverage, interactive shell), federated terminology across the UI and CLI |
 | 0.7.1    | v0.7.1         | Topology view fixes (federated facility L2 rendering), authenticated weave runs, raised upload size limit, deployment hardening |
@@ -33,17 +34,17 @@ AI-assisted experiment designer for the [FABRIC testbed](https://fabric-testbed.
 
 | Port | Service | Description |
 |------|---------|-------------|
-| 3000 | Nginx | Web UI frontend |
-| 8000 | Uvicorn | FastAPI backend API |
-| 8889 | JupyterLab | Per-slice notebook environments |
-| 9100-9199 | SSH Proxy | Tunnel proxies for VM web apps |
+| 3000 | Nginx | Web UI frontend — the only entrypoint; proxies `/api`, `/jupyter`, `/aider`, `/opencode`, `/tunnel` with the session auth gate |
+| 8000 | Uvicorn | FastAPI backend API (internal — reach via nginx on 3000) |
+| 8889 | JupyterLab | Per-slice notebook environments (internal — reach via nginx on 3000 so auth applies) |
+| 9100-9199 | SSH Proxy | Tunnel proxies for VM web apps (publish on loopback only — direct access bypasses the auth gate; remote users go through `/tunnel/` on 3000) |
 
 ## Usage
 
 ### Docker Compose (recommended)
 
 ```bash
-curl -O https://raw.githubusercontent.com/fabric-testbed/fabric-docker-images/main/loomai/0.7.3/docker-compose.yml
+curl -O https://raw.githubusercontent.com/fabric-testbed/fabric-docker-images/main/loomai/0.8.2/docker-compose.yml
 docker compose up -d
 ```
 
@@ -55,16 +56,21 @@ docker compose logs | grep "LoomAI password"
 ### Docker Run
 
 ```bash
-docker pull fabrictestbed/loomai:0.7.3
+docker pull fabrictestbed/loomai:0.8.2
 docker run -d \
-  -p 3000:3000 -p 8000:8000 -p 8889:8889 -p 9100-9199:9100-9199 \
+  -p 127.0.0.1:3000:3000 -p 127.0.0.1:9100-9199:9100-9199 \
   -v fabric_work:/home/fabric/work \
   -e FABRIC_CONFIG_DIR=/home/fabric/work/fabric_config \
   -e FABRIC_STORAGE_DIR=/home/fabric/work \
   --dns 8.8.8.8 --dns 8.8.4.4 \
   --restart unless-stopped \
-  fabrictestbed/loomai:0.7.3
+  fabrictestbed/loomai:0.8.2
 ```
+
+Ports are bound to `127.0.0.1` on purpose: the tunnel proxies (9100-9199) have no
+authentication of their own — only the nginx `/tunnel/` route on 3000 enforces the
+session auth gate. To expose LoomAI remotely, publish only 3000 (ideally behind
+HTTPS) and let nginx proxy everything else.
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
Adds the LoomAI 0.8.2 Docker image recipe, following the same layout as prior versions.

## Changes
- **`loomai/0.8.2/Dockerfile`** — regenerated from the actual `Dockerfile` at the `v0.8.2` tag of `fabric-testbed/loomai`, adapted to this repo's clone-from-tag pattern (`ARG LOOMAI_VERSION=v0.8.2` + `alpine/git` source stage). The 0.7.3 recipe had drifted from the source; 0.8.2 picks up:
  - nginx upload temp-dir fix (`client_body_temp_path` under the writable storage mount)
  - 30-minute proxy timeouts for long-running slice operations (post-boot-config, network auto-config, site re-resolution)
  - session auth gate (`auth_request`) on the JupyterLab / Aider / OpenCode / tunnel proxies
  - writable matplotlib cache (`MPLCONFIGDIR` on the storage mount) and `LOOMAI_COMBINED_IMAGE=1`
  - Passes `docker buildx build --check` with no warnings.
- **`loomai/0.8.2/docker-compose.yml`** — from the v0.8.2 source with the image pinned to `fabrictestbed/loomai:0.8.2`. Ports 8000/8889 are intentionally no longer published; everything goes through nginx on 3000 so the auth gate applies.
- **`loomai/README.md`** — 0.8.2 version-table row, examples bumped to 0.8.2, `docker run` example binds to `127.0.0.1` (direct access to the tunnel ports 9100-9199 bypasses the auth gate), and a note on safe remote exposure.
